### PR TITLE
Add other-modules to cabal

### DIFF
--- a/postgresql-wire-protocol.cabal
+++ b/postgresql-wire-protocol.cabal
@@ -56,6 +56,9 @@ library
     Database.PostgreSQL.Protocol.Readers
     Database.PostgreSQL.Protocol.Types
 
+  other-modules:
+    Database.PostgreSQL.Protocol.Internal.Builders
+
   build-depends:
     array                   >= 0.5.1.0,
     base                    >= 4.8 && < 5,


### PR DESCRIPTION
According to cabal documentation, cabal should be aware of all the modules.
Database.PostgreSQL.Protocol.Frontend might not be actually needed.
But Database.PostgreSQL.Protocol.Internal.Builders is needed.
